### PR TITLE
Fix deleted flag being incorrectly set to the wrong value

### DIFF
--- a/FastDBF/DbfRecord.cs
+++ b/FastDBF/DbfRecord.cs
@@ -105,6 +105,10 @@ namespace SocialExplorer.IO.FastDBF
 
             //create a buffer to hold all record data. We will reuse this buffer to write all data to the file.
             _data = new byte[_header.RecordLength];
+
+            // Make sure mData[0] correctly represents 'not deleted'
+            IsDeleted = false;
+
             _emptyRecord = _header.EmptyDataRecord;
             encoding = oHeader.encoding;
 


### PR DESCRIPTION
As per issue 3 (https://github.com/SocialExplorer/FastDBF/issues/3) I found an issue where mData is initialized in the DbfRecord constructor leaving mData[0] == 0. I believe the valid values would be either '*' or ' ' as described in the setter of IsDeleted.

This should fix the issue.