### PR TITLE
Properly closing and disposing Stream object which may cause file lock issues.

### DIFF
--- a/FastDBF/DbfFile.cs
+++ b/FastDBF/DbfFile.cs
@@ -229,7 +229,10 @@ namespace SocialExplorer.IO.FastDBF
                 _dbfFileReader.Close();
 
             if (_dbfFile != null)
+            {
                 _dbfFile.Close();
+                _dbfFile.Dispose();
+            }
 
 
             //set streams to null


### PR DESCRIPTION
Properly closing and disposing Steam object which may cause file lock issues while reading another file after reading one or more file.